### PR TITLE
Filter out fixed alerts

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ cluster-app
         GHSA-w7rc-rwvf-8q5r      LOW The `size` option isn't honored after following a redirect in node-fetch
 ```
 
-The GraphQL API does expose whether vulnerability alerts are actually enabled. You can enable vulnerability alerts across your organization on the [Configure security and analysis features] page.
+The GraphQL API does expose whether vulnerability alerts are actually enabled. You can enable vulnerability alerts
+across your organization on the [Configure security and analysis features] page.
 
 [GitHub personal access token]: https://github.com/settings/tokens
 [Configure security and analysis features]: https://github.com/organizations/CumulusDS/settings/security_analysis

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,7 @@ query OrganizationRepositories($after: String) {
         vulnerabilityAlerts(first: 100) {
           nodes {
             dismissedAt,
+            fixedAt,
             securityVulnerability {
               advisory { ghsaId, summary },
               severity
@@ -56,6 +57,7 @@ type Severity = $Keys<typeof label>;
 
 type Node = {
   dismissedAt: ?string,
+  fixedAt: ?string,
   securityVulnerability: { advisory: { ghsaId: string, summary: string }, severity: Severity }
 };
 
@@ -95,7 +97,9 @@ export default async function main() {
       name,
       vulnerabilityAlerts: { nodes }
     } = repository;
-    const vulnerabilities = nodes.filter(({ dismissedAt }) => dismissedAt == null);
+    const vulnerabilities = nodes
+      .filter(({ dismissedAt }) => dismissedAt == null)
+      .filter(({ fixedAt }) => fixedAt == null);
     if (vulnerabilities.length > 0) {
       const advisories: Advisory[] = vulnerabilities
         .map(({ securityVulnerability: { advisory: { ghsaId, summary }, severity } }) => ({

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -18,6 +18,7 @@ jest.mock("@octokit/graphql", () => ({
                   nodes: [
                     {
                       dismissedAt: "2020-10-22T01:35:51Z",
+                      fixedAt: null,
                       securityVulnerability: {
                         advisory: { ghsaId: "id-1", summary: "summary-1" },
                         severity: "HIGH"
@@ -43,6 +44,7 @@ jest.mock("@octokit/graphql", () => ({
                   nodes: [
                     {
                       dismissedAt: null,
+                      fixedAt: null,
                       securityVulnerability: {
                         advisory: { ghsaId: "id-2", summary: "summary-2" },
                         severity: "HIGH"
@@ -50,6 +52,7 @@ jest.mock("@octokit/graphql", () => ({
                     },
                     {
                       dismissedAt: null,
+                      fixedAt: null,
                       securityVulnerability: {
                         advisory: { ghsaId: "id-3", summary: "summary-3" },
                         severity: "LOW"
@@ -57,6 +60,7 @@ jest.mock("@octokit/graphql", () => ({
                     },
                     {
                       dismissedAt: null,
+                      fixedAt: null,
                       securityVulnerability: {
                         advisory: { ghsaId: "id-4", summary: "summary-4" },
                         severity: "HIGH"


### PR DESCRIPTION
# Summary
## What does this PR do?
Filters out fixed alerts from vulnerability report

# Details
## Why did you make this change? What does it affect?
The package was showing fixed vulnerability alerts due to a change in Dependabot from github.  This now gets us a better filtered list

# Testing
## How can the other reviewers check that your change works?

`master` branch of cma shows a laundry list of vulnerabilities prior to these changes when there is only one at the time of this writing

![Screen Shot 2022-04-05 at 4 15 33 PM](https://user-images.githubusercontent.com/49158344/161841515-b709658e-e850-4fd2-84dd-a981ea48f9cd.png)

There is currently only one vulnerability in the CMA repo, and now this shows properly here
![Screen Shot 2022-04-05 at 4 16 24 PM](https://user-images.githubusercontent.com/49158344/161841624-8973f23e-707e-4c22-b786-35a551179851.png)

<details><summary>side-by-side comparison</summary>

![Screen Shot 2022-04-05 at 4 17 11 PM](https://user-images.githubusercontent.com/49158344/161841745-048f50f0-061d-49b1-be6c-7838082b4935.png)

</details>
