### PR TITLE
Update dependabot config for automated update of private CumulusDS NPM packages

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,9 @@
 version: 2
-
+registries:
+  npm-npmjs:
+    type: npm-registry
+    url: https://registry.npmjs.org
+    token: ${{ secrets.NODE_AUTH_TOKEN }}
 updates:
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -13,3 +17,21 @@ updates:
       - "jeffsays"
     reviewers:
       - "jeffsays"
+  - package-ecosystem: "npm"
+    directory: "/"
+    registries:
+      - npm-npmjs
+    schedule:
+      interval: "daily"
+      time: "07:30"
+      timezone: "America/New_York"
+    labels:
+      - "dependencies"
+      - "dependabot"
+    assignees:
+      - "jeffsays"
+    reviewers:
+      - "jeffsays"
+    allow:
+      - dependency-name: "@cumulusds/*"
+        dependency-type: "all"


### PR DESCRIPTION
# Summary
## What does this PR do?
Updates `dependabot.yml` with private registry access to automatically open pull requests when there are updated versions of private Cumulus npm packages

# Details
## Why did you make this change? What does it affect?
Automate updates

# Testing
## How can the other reviewers check that your change works?
Tested successfully on leaderboard: https://github.com/CumulusDS/sts-leaderboard/pull/204

PRs automatically created after merging:
- https://github.com/CumulusDS/sts-leaderboard/pull/205
- https://github.com/CumulusDS/sts-leaderboard/pull/206

If there are any relevant packages in need of update in this project, dependabot will open up pull request(s) within a few minutes post merge of this PR