### PR TITLE
Resolve `CVE-2023-26115` - vulnerability in `word-wrap`

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -7378,10 +7378,10 @@ which@^2.0.1, which@^2.0.2:
   dependencies:
     isexe "^2.0.0"
 
-word-wrap@^1.2.3, word-wrap@~1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.3.tgz#610636f6b1f703891bd34771ccb17fb93b47079c"
-  integrity sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+word-wrap@^1.2.3, word-wrap@^1.2.4, word-wrap@~1.2.3:
+  version "1.2.5"
+  resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
+  integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
 wrap-ansi@^6.2.0:
   version "6.2.0"


### PR DESCRIPTION
# Summary
## What does this PR do?
- Resolve CVE-2023-26115 - vulnerability in `word-wrap` versions older than 1.2.4
  | Affected versions | Patched versions |
  |-|-|
  | <= 1.2.3 | 1.2.4 |

# Testing
## How can the other reviewers check that your change works?
build should pass

```zsh
[1/4] 🤔  Why do we have the module "word-wrap"...?
[2/4] 🚚  Initialising dependency graph...
[3/4] 🔍  Finding dependency...
[4/4] 🚡  Calculating file sizes...
=> Found "word-wrap@1.2.5"
info Reasons this module exists
   - "optionator" depends on it
   - Hoisted from "optionator#word-wrap"
   - Hoisted from "@cumulusds#flow-coverage-report#@cumulusds#flow-annotation-check#eslint#optionator#word-wrap"
info Disk size without dependencies: "24KB"
info Disk size with unique dependencies: "24KB"
info Disk size with transitive dependencies: "24KB"
info Number of shared dependencies: 0
```