### PR TITLE
Upgrade  to finish resolving CVE-2017-16137

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -3643,15 +3643,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"debug@npm:4, debug@npm:^4.1.1":
-  version: 4.3.3
-  resolution: "debug@npm:4.3.3"
+"debug@npm:4, debug@npm:^4.0.1, debug@npm:^4.1.0, debug@npm:^4.1.1, debug@npm:^4.3.3":
+  version: 4.3.4
+  resolution: "debug@npm:4.3.4"
   dependencies:
     ms: 2.1.2
   peerDependenciesMeta:
     supports-color:
       optional: true
-  checksum: 14472d56fe4a94dbcfaa6dbed2dd3849f1d72ba78104a1a328047bb564643ca49df0224c3a17fa63533fd11dd3d4c8636cd861191232a2c6735af00cc2d4de16
+  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
   languageName: node
   linkType: hard
 
@@ -3665,32 +3665,11 @@ __metadata:
   linkType: hard
 
 "debug@npm:^3.1.0":
-  version: 3.2.6
-  resolution: "debug@npm:3.2.6"
+  version: 3.2.7
+  resolution: "debug@npm:3.2.7"
   dependencies:
     ms: ^2.1.1
-  checksum: 07bc8b3a13ef3cfa6c06baf7871dfb174c291e5f85dbf566f086620c16b9c1a0e93bb8f1935ebbd07a683249e7e30286f2966e2ef461e8fd17b1b60732062d6b
-  languageName: node
-  linkType: hard
-
-"debug@npm:^4.0.1":
-  version: 4.1.1
-  resolution: "debug@npm:4.1.1"
-  dependencies:
-    ms: ^2.1.1
-  checksum: 1e681f5cce94ba10f8dde74b20b42e4d8cf0d2a6700f4c165bb3bb6885565ef5ca5885bf07e704974a835f2415ff095a63164f539988a1f07e8a69fe8b1d65ad
-  languageName: node
-  linkType: hard
-
-"debug@npm:^4.1.0, debug@npm:^4.3.3":
-  version: 4.3.4
-  resolution: "debug@npm:4.3.4"
-  dependencies:
-    ms: 2.1.2
-  peerDependenciesMeta:
-    supports-color:
-      optional: true
-  checksum: 3dbad3f94ea64f34431a9cbf0bafb61853eda57bff2880036153438f50fb5a84f27683ba0d8e5426bf41a8c6ff03879488120cf5b3a761e77953169c0600a708
+  checksum: b3d8c5940799914d30314b7c3304a43305fd0715581a919dacb8b3176d024a782062368405b47491516d2091d6462d4d11f2f4974a405048094f8bfebfa3071c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
## What does this PR do?
- Finish resolving CVE-2017-16137
  | Affected versions | Patched versions |
  |-|-|
  | < 2.6.9 | 2.6.9 |
  | >= 3.0.0, < 3.1.0 | 3.1.0 |
  | >= 3.2.0, < 3.2.7 | 3.2.7 |
  | >= 4.0.0, < 4.3.1 | 4.3.1 |
```zsh
   └─ debug@npm:4.3.4 [68fa1] (via npm:^4.1.0 [68fa1])
│  └─ debug@npm:2.6.9 (via npm:^2.6.8)
│  └─ debug@npm:2.6.9 (via npm:^2.6.9)
│  └─ debug@npm:2.6.9 [2bcc4] (via npm:^2.2.0 [2bcc4])
│  └─ debug@npm:3.2.7 [44cf7] (via npm:^3.1.0 [44cf7])
│  └─ debug@npm:4.3.4 [68fa1] (via npm:^4.1.0 [68fa1])
```

# Testing
## How can the other reviewers check that your change works?
build should pass
