### PR TITLE
Report the last 100 vulnerability alerts

### DIFF
--- a/src/generateOrganizationRepositories.js
+++ b/src/generateOrganizationRepositories.js
@@ -27,7 +27,7 @@ query OrganizationRepositories($after: String) {
         isArchived,
         name,
         hasVulnerabilityAlertsEnabled,
-        vulnerabilityAlerts(first: 100) {
+        vulnerabilityAlerts(last: 100) {
           nodes {
             createdAt,
             dismissedAt,


### PR DESCRIPTION
Report the last 100 vulnerability alerts rather than the first 100. This shows the most recent alerts. It fixes a problem where a repo with a history of more than 100 alerts was not correctly reporting recent alerts.