### PR TITLE
Upgrade `ws` to resolve CVE-2024-37890

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -11092,8 +11092,8 @@ __metadata:
   linkType: hard
 
 "ws@npm:^7.4.6":
-  version: 7.5.6
-  resolution: "ws@npm:7.5.6"
+  version: 7.5.10
+  resolution: "ws@npm:7.5.10"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ^5.0.2
@@ -11102,7 +11102,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 0c2ffc9a539dd61dd2b00ff6cc5c98a3371e2521011fe23da4b3578bb7ac26cbdf7ca8a68e8e08023c122ae247013216dde2a20c908de415a6bcc87bdef68c87
+  checksum: f9bb062abf54cc8f02d94ca86dcd349c3945d63851f5d07a3a61c2fcb755b15a88e943a63cf580cbdb5b74436d67ef6b67f745b8f7c0814e411379138e1863cb
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
## What does this PR do?
- Bump `ws` package to resolve CVE-2024-37890
  | Affected versions | Patched versions |
  |-|-|
  | < 7.5.10 | 7.5.10 |

### Before
```zsh
yarn why ws
   └─ ws@npm:7.5.6 [d1d74] (via npm:^7.4.6 [d1d74])
│  └─ ws@npm:7.5.6 (via npm:^7.4.6)



```

### After
```zsh
yarn why ws
   └─ ws@npm:7.5.10 [d1d74] (via npm:^7.4.6 [d1d74])
│  └─ ws@npm:7.5.10 (via npm:^7.4.6)


=
```

# Testing
## How can the other reviewers check that your change works?
build should pass
