### PR TITLE
Upgrade `tar` to resolve CVE-2024-28863

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -10267,8 +10267,8 @@ __metadata:
   linkType: hard
 
 "tar@npm:^6.1.11, tar@npm:^6.1.2":
-  version: 6.2.0
-  resolution: "tar@npm:6.2.0"
+  version: 6.2.1
+  resolution: "tar@npm:6.2.1"
   dependencies:
     chownr: ^2.0.0
     fs-minipass: ^2.0.0
@@ -10276,7 +10276,7 @@ __metadata:
     minizlib: ^2.1.1
     mkdirp: ^1.0.3
     yallist: ^4.0.0
-  checksum: db4d9fe74a2082c3a5016630092c54c8375ff3b280186938cfd104f2e089c4fd9bad58688ef6be9cf186a889671bf355c7cda38f09bbf60604b281715ca57f5c
+  checksum: f1322768c9741a25356c11373bce918483f40fa9a25c69c59410c8a1247632487edef5fe76c5f12ac51a6356d2f1829e96d2bc34098668a2fc34d76050ac2b6c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
## What does this PR do?
- Bump `tar` package to resolve CVE-2024-28863
  | Affected versions | Patched versions |
  |-|-|
  | < 6.2.1 | 6.2.1 |

### Before
```zsh
yarn why tar
   └─ tar@npm:6.2.0 (via npm:^6.1.2)
│  └─ tar@npm:6.2.0 (via npm:^6.1.11)



```

### After
```zsh
yarn why tar
   └─ tar@npm:6.2.1 (via npm:^6.1.2)
│  └─ tar@npm:6.2.1 (via npm:^6.1.11)



```

# Testing
## How can the other reviewers check that your change works?
build should pass
