### PR TITLE
Upgrade `micromatch` to resolve CVE-2024-4067

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -6954,12 +6954,12 @@ __metadata:
   linkType: hard
 
 "micromatch@npm:^4.0.4":
-  version: 4.0.7
-  resolution: "micromatch@npm:4.0.7"
+  version: 4.0.8
+  resolution: "micromatch@npm:4.0.8"
   dependencies:
     braces: ^3.0.3
     picomatch: ^2.3.1
-  checksum: 3cde047d70ad80cf60c787b77198d680db3b8c25b23feb01de5e2652205d9c19f43bd81882f69a0fd1f0cde6a7a122d774998aad3271ddb1b8accf8a0f480cf7
+  checksum: 79920eb634e6f400b464a954fcfa589c4e7c7143209488e44baf627f9affc8b1e306f41f4f0deedde97e69cb725920879462d3e750ab3bd3c1aed675bb3a8966
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
# Summary
## What does this PR do?
- Bump `micromatch` package to resolve CVE-2024-4067
  | Affected versions | Patched versions |
  |-|-|
  | < 4.0.8 | 4.0.8 |

### Before
```zsh
yarn why micromatch
   └─ micromatch@npm:4.0.7 (via npm:^4.0.4)
│  └─ micromatch@npm:4.0.7 (via npm:^4.0.4)



```

### After
```zsh
yarn why micromatch
   └─ micromatch@npm:4.0.8 (via npm:^4.0.4)
│  └─ micromatch@npm:4.0.8 (via npm:^4.0.4)



```

# Testing
## How can the other reviewers check that your change works?
build should pass
